### PR TITLE
Update cmakefiles to use msvc and vcpkg toolchain on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,7 @@ opentxs-proto.kdev4
 *.rej
 *.orig
 
+# Visual Studio Code noise
+.vs
+
 /build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,9 @@ set(LIBRARY_OUTPUT_PATH  ${CMAKE_CURRENT_BINARY_DIR}/lib)
 INCLUDE(CheckCXXCompilerFlag)
 CHECK_CXX_COMPILER_FLAG(-std=c++17 HAVE_STD17)
 
-if(HAVE_STD17)
+if (MSVC)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++17")
+elseif(HAVE_STD17)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
 else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1z")
@@ -281,6 +283,13 @@ endfunction(set_lib_property)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 include_directories(SYSTEM ${CMAKE_CURRENT_BINARY_DIR}/src)
+
+# Fix for vcpkg: add the include directory
+
+if (VCPKG_TOOLCHAIN)
+  find_path(PROTOBUF_INCLUDES google/protobuf/stubs/common.h)
+  include_directories(${PROTOBUF_INCLUDES})
+endif()
 
 add_subdirectory(src)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,19 +23,33 @@ if(NOT OT_BUNDLED_OPENTXS_PROTO)
     $<TARGET_OBJECTS:verify>
   )
 
-  target_link_libraries(${MODULE_NAME}
-    PUBLIC
-    ${PROTOBUF_LITE_LIBRARIES}
-    PRIVATE
-    ${OPENTXS_SYSTEM_LIBRARIES}
-  )
-
-  target_link_libraries(${MODULE_NAME}_static
-    PUBLIC
-    ${PROTOBUF_LITE_LIBRARIES}
-    PRIVATE
-    ${OPENTXS_SYSTEM_LIBRARIES}
-  )
+  if (NOT PROTOBUF_LITE_LIBRARIES)
+    target_link_libraries(${MODULE_NAME}
+      PUBLIC
+      ${PROTOBUF_LIBRARIES}
+      PRIVATE
+      ${OPENTXS_SYSTEM_LIBRARIES}
+    )
+    target_link_libraries(${MODULE_NAME}_static
+      PUBLIC
+      ${PROTOBUF_LIBRARIES}
+      PRIVATE
+      ${OPENTXS_SYSTEM_LIBRARIES}
+    )
+  else()
+    target_link_libraries(${MODULE_NAME}
+      PUBLIC
+      ${PROTOBUF_LITE_LIBRARIES}
+      PRIVATE
+      ${OPENTXS_SYSTEM_LIBRARIES}
+    )
+    target_link_libraries(${MODULE_NAME}_static
+      PUBLIC
+      ${PROTOBUF_LITE_LIBRARIES}
+      PRIVATE
+      ${OPENTXS_SYSTEM_LIBRARIES}
+    )
+  endif()
 
   set_target_properties(${MODULE_NAME} PROPERTIES OUTPUT_NAME ${MODULE_NAME})
   set_target_properties(${MODULE_NAME}_static PROPERTIES OUTPUT_NAME ${MODULE_NAME})

--- a/src/opentxs-proto/CMakeLists.txt
+++ b/src/opentxs-proto/CMakeLists.txt
@@ -158,7 +158,9 @@ add_library(${MODULE_NAME} OBJECT
   ${PROTO_HEADER}
 )
 
-target_compile_options(${MODULE_NAME} PRIVATE -Wno-error -Wno-unused-macros -Wno-undef -Wno-switch-default)
+if(NOT MSVC)
+  target_compile_options(${MODULE_NAME} PRIVATE -Wno-unused-macros -Wno-undef -Wno-switch-default)
+endif()
 
 if (PYTHON OR PYTHON2 OR PYTHON3)
     # why doesn't this work?  For some reason it doesn't actually generate .py files'

--- a/tests/bip47/CMakeLists.txt
+++ b/tests/bip47/CMakeLists.txt
@@ -16,6 +16,10 @@ add_executable(${name} ${cxx-sources}  $<TARGET_OBJECTS:generated> $<TARGET_OBJE
 
 set_target_properties(${name} PROPERTIES ENABLE_EXPORTS 1 RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/tests)
 
-target_link_libraries(${name} ${PROTOBUF_LITE_LIBRARIES} ${GTEST_LIBRARY})
+if (PROTOBUF_LITE_LIBRARIES)
+  target_link_libraries(${name} ${PROTOBUF_LITE_LIBRARIES} ${GTEST_LIBRARY})
+else()
+  target_link_libraries(${name} ${PROTOBUF_LIBRARIES} ${GTEST_LIBRARY})
+endif()
 
 add_test(${name} ${PROJECT_BINARY_DIR}/tests/${name} --gtest_output=xml:gtestresults.xml)

--- a/tests/storage_bip47/CMakeLists.txt
+++ b/tests/storage_bip47/CMakeLists.txt
@@ -15,5 +15,9 @@ set(cxx-sources
 
 add_executable(${name} ${cxx-sources}  $<TARGET_OBJECTS:generated> $<TARGET_OBJECTS:verify>)
 set_target_properties(${name} PROPERTIES ENABLE_EXPORTS 1 RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/tests)
-target_link_libraries(${name} ${PROTOBUF_LITE_LIBRARIES} ${GTEST_LIBRARY})
+if (PROTOBUF_LITE_LIBRARIES)
+  target_link_libraries(${name} ${PROTOBUF_LITE_LIBRARIES} ${GTEST_LIBRARY})
+else()
+  target_link_libraries(${name} ${PROTOBUF_LIBRARIES} ${GTEST_LIBRARY})
+endif()
 add_test(${name} ${PROJECT_BINARY_DIR}/tests/${name} --gtest_output=xml:gtestresults.xml)

--- a/tests/storage_nym/CMakeLists.txt
+++ b/tests/storage_nym/CMakeLists.txt
@@ -12,5 +12,9 @@ set(cxx-sources
 
 add_executable(${name} ${cxx-sources}  $<TARGET_OBJECTS:generated> $<TARGET_OBJECTS:verify>)
 set_target_properties(${name} PROPERTIES ENABLE_EXPORTS 1 RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/tests)
-target_link_libraries(${name} ${PROTOBUF_LITE_LIBRARIES} ${GTEST_LIBRARY})
+if (PROTOBUF_LITE_LIBRARIES)
+  target_link_libraries(${name} ${PROTOBUF_LITE_LIBRARIES} ${GTEST_LIBRARY})
+else()
+  target_link_libraries(${name} ${PROTOBUF_LIBRARIES} ${GTEST_LIBRARY})
+endif()
 add_test(${name} ${PROJECT_BINARY_DIR}/tests/${name} --gtest_output=xml:gtestresults.xml)

--- a/tests/storage_nymlist/CMakeLists.txt
+++ b/tests/storage_nymlist/CMakeLists.txt
@@ -12,5 +12,9 @@ set(cxx-sources
 
 add_executable(${name} ${cxx-sources}  $<TARGET_OBJECTS:generated> $<TARGET_OBJECTS:verify>)
 set_target_properties(${name} PROPERTIES ENABLE_EXPORTS 1 RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/tests)
-target_link_libraries(${name} ${PROTOBUF_LITE_LIBRARIES} ${GTEST_LIBRARY})
+if (PROTOBUF_LITE_LIBRARIES)
+  target_link_libraries(${name} ${PROTOBUF_LITE_LIBRARIES} ${GTEST_LIBRARY})
+else()
+  target_link_libraries(${name} ${PROTOBUF_LIBRARIES} ${GTEST_LIBRARY})
+endif()
 add_test(${name} ${PROJECT_BINARY_DIR}/tests/${name} --gtest_output=xml:gtestresults.xml)


### PR DESCRIPTION
Protobuf lite is unavailable after `vcpkg install protobuf`, include paths are not added by default when using vcpkg toolchain (ref: https://github.com/Microsoft/vcpkg/commit/a6957ebf389648e2b2253e9b18f83d6a1508ab10)